### PR TITLE
updating startup processes in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MAS - Multi-Agent System for EMIS
+ # MAS - Multi-Agent System for EMIS
 
 A production-grade Education Management Information System (EMIS) agent built with LangGraph, featuring intelligent tool orchestration, human-in-the-loop interactions, and streaming API capabilities.
 
@@ -116,7 +116,7 @@ pip install -e ".[dev]"
 First, ensure you have an OpenAPI-compatible backend running on `http://localhost:8080`, then start the MCP server:
 
 ```bash
-python my_mcp_server.py
+source .venv/bin/activate && fastmcp run my_mcp_server.py --transport=http --port=8000
 ```
 
 The MCP server will be available at `http://localhost:8000/mcp`
@@ -130,7 +130,7 @@ python streaming_api.py
 Or using uvicorn directly:
 
 ```bash
-uvicorn streaming_api:app --host 0.0.0.0 --port 8000 --reload
+source .venv/bin/activate && uvicorn streaming_api:app --host 0.0.0.0 --port 8001 --log-level info
 ```
 
 The API will be available at:
@@ -337,7 +337,7 @@ Error: Tool 'xyz' not found
 
 **Solution**: 
 1. Verify the backend API is running on `http://localhost:8080`
-2. Check the OpenAPI spec is accessible: `curl http://localhost:8080/v3/api-docs`
+2. Check the OpenAPI spec is accessible: `curl http://localhost:8080/v3/api-docs` 
 3. Restart the FastMCP server
 
 #### 4. Parallel Tool Execution Issues


### PR DESCRIPTION
This pull request updates the `README.md` to improve instructions for running the MCP server and the streaming API. The changes clarify the recommended commands and ensure users activate the virtual environment before starting the servers.

**Documentation improvements:**

* Updated the MCP server startup instructions to use `fastmcp run` with explicit transport and port options, and added activation of the virtual environment (`source .venv/bin/activate`) for proper environment setup.
* Revised the streaming API example to activate the virtual environment and changed the port to `8001` with additional `uvicorn` logging options for better debugging.